### PR TITLE
Record keys up time

### DIFF
--- a/Vimfinity.Tests/KeysRecordTest.cs
+++ b/Vimfinity.Tests/KeysRecordTest.cs
@@ -2,9 +2,9 @@ using System.Windows.Forms;
 
 namespace Vimfinity.Tests;
 
-public class KeysStateTest
+public class KeysRecordTest
 {
-	private void AssertKeyDown(KeysState state, Keys key, DateTime time, long expectedDownDurationTicks)
+	private void AssertKeyDown(KeysRecord state, Keys key, DateTime time, long expectedDownDurationTicks)
 	{
 		TimeSpan? downDuration = state.GetKeyDownDuration(key, time);
 		Assert.NotNull(downDuration);
@@ -12,7 +12,7 @@ public class KeysStateTest
 		Assert.True(state.IsKeyDown(key));
 	}
 
-	private void AssertKeysUp(KeysState state, ISet<Keys> excludedKeys)
+	private void AssertKeysUp(KeysRecord state, ISet<Keys> excludedKeys)
 	{
 		foreach (var key in Enum.GetValues<Keys>().Where(k => !excludedKeys.Contains(k)))
 		{
@@ -21,7 +21,7 @@ public class KeysStateTest
 		}
 	}
 
-	private void AssertKeysUpDuration(KeysState state, DateTime time, IDictionary<Keys, long>? upDurationTicks = null)
+	private void AssertKeysUpDuration(KeysRecord state, DateTime time, IDictionary<Keys, long>? upDurationTicks = null)
 	{
 		foreach (var key in Enum.GetValues<Keys>())
 		{
@@ -41,7 +41,7 @@ public class KeysStateTest
 	[Fact]
 	public void NoKeysInitiallyDown_Test()
 	{
-		KeysState state = new();
+		KeysRecord state = new();
 
 		AssertKeysUp(state, new HashSet<Keys>());
 		AssertKeysUpDuration(state, new DateTime(0));
@@ -51,7 +51,7 @@ public class KeysStateTest
 	[Fact]
 	public void Record_Test()
 	{
-		KeysState state = new();
+		KeysRecord state = new();
 		state.Record(new(Keys.A, KeyPressedState.Down), new DateTime(10));
 
 		AssertKeyDown(state, Keys.A, new DateTime(30), 20);
@@ -84,7 +84,7 @@ public class KeysStateTest
 	[Fact]
 	public void RecordMultiple_Test()
 	{
-		KeysState state = new();
+		KeysRecord state = new();
 		state.Record(new(Keys.A, KeyPressedState.Down), new DateTime(10));
 		state.Record(new(Keys.A, KeyPressedState.Down), new DateTime(20));
 		state.Record(new(Keys.A, KeyPressedState.Down), new DateTime(30));
@@ -113,7 +113,7 @@ public class KeysStateTest
 	[Fact]
 	public void RecordModifiers_Test()
 	{
-		KeysState state = new();
+		KeysRecord state = new();
 
 		AssertKeysUp(state, excludedKeys: new HashSet<Keys>());
 		Assert.Equal(KeyModifierFlags.None, state.GetKeyModifiersDown());
@@ -152,7 +152,7 @@ public class KeysStateTest
 	[Fact]
 	public void RecordLeftRightModifiers_Test()
 	{
-		KeysState state = new();
+		KeysRecord state = new();
 
 		AssertKeysUp(state, excludedKeys: new HashSet<Keys>());
 		Assert.Equal(KeyModifierFlags.None, state.GetKeyModifiersDown());

--- a/Vimfinity.Tests/KeysRecordTest.cs
+++ b/Vimfinity.Tests/KeysRecordTest.cs
@@ -16,7 +16,7 @@ public class KeysRecordTest
 	{
 		foreach (var key in Enum.GetValues<Keys>().Where(k => !excludedKeys.Contains(k)))
 		{
-			Assert.Null(state.GetKeyDownDuration(key));
+			Assert.Null(state.GetKeyDownDuration(key, new DateTime(0)));
 			Assert.False(state.IsKeyDown(key));
 		}
 	}
@@ -175,5 +175,15 @@ public class KeysRecordTest
 		AssertKeyDown(state, Keys.Shift, new DateTime(30), 25);
 		AssertKeysUp(state, new HashSet<Keys> { Keys.LShiftKey, Keys.RShiftKey, Keys.ShiftKey, Keys.Shift, Keys.Modifiers });
 		Assert.Equal(KeyModifierFlags.Shift, state.GetKeyModifiersDown());
+	}
+
+	[Fact]
+	public void RecordUpWithoutDown_Test()
+	{
+		KeysRecord state = new();
+
+		state.Record(new(Keys.A, KeyPressedState.Up), new DateTime(10));
+
+		AssertKeysUpDuration(state, new DateTime(30), new Dictionary<Keys, long> { { Keys.A, 20 } });
 	}
 }

--- a/Vimfinity.Tests/KeysStateTest.cs
+++ b/Vimfinity.Tests/KeysStateTest.cs
@@ -21,12 +21,30 @@ public class KeysStateTest
 		}
 	}
 
+	private void AssertKeysUpDuration(KeysState state, DateTime time, IDictionary<Keys, long>? upDurationTicks = null)
+	{
+		foreach (var key in Enum.GetValues<Keys>())
+		{
+			TimeSpan? duration = state.GetKeyUpDuration(key, time);
+			if (upDurationTicks != null && upDurationTicks.TryGetValue(key, out long ticks))
+			{
+				Assert.NotNull(duration);
+				Assert.Equal(ticks, duration.Value.Ticks);
+			}
+			else
+			{
+				Assert.Null(duration);
+			}
+		}
+	}
+
 	[Fact]
 	public void NoKeysInitiallyDown_Test()
 	{
 		KeysState state = new();
 
 		AssertKeysUp(state, new HashSet<Keys>());
+		AssertKeysUpDuration(state, new DateTime(0));
 		Assert.Equal(KeyModifierFlags.None, state.GetKeyModifiersDown());
 	}
 
@@ -38,6 +56,7 @@ public class KeysStateTest
 
 		AssertKeyDown(state, Keys.A, new DateTime(30), 20);
 		AssertKeysUp(state, excludedKeys: new HashSet<Keys> { Keys.A });
+		AssertKeysUpDuration(state, new DateTime(0));
 		Assert.Equal(KeyModifierFlags.None, state.GetKeyModifiersDown());
 
 		state.Record(new(Keys.B, KeyPressedState.Down), new DateTime(50));
@@ -45,17 +64,20 @@ public class KeysStateTest
 		AssertKeyDown(state, Keys.A, new DateTime(30), 20);
 		AssertKeyDown(state, Keys.B, new DateTime(110), 60);
 		AssertKeysUp(state, excludedKeys: new HashSet<Keys> { Keys.A, Keys.B });
+		AssertKeysUpDuration(state, new DateTime(0));
 		Assert.Equal(KeyModifierFlags.None, state.GetKeyModifiersDown());
 
 		state.Record(new(Keys.B, KeyPressedState.Up), new DateTime(120));
 
 		AssertKeyDown(state, Keys.A, new DateTime(30), 20);
 		AssertKeysUp(state, excludedKeys: new HashSet<Keys> { Keys.A });
+		AssertKeysUpDuration(state, new DateTime(130), new Dictionary<Keys, long> { { Keys.B, 10 } });
 		Assert.Equal(KeyModifierFlags.None, state.GetKeyModifiersDown());
 
 		state.Record(new(Keys.A, KeyPressedState.Up), new DateTime(130));
 
 		AssertKeysUp(state, excludedKeys: new HashSet<Keys>());
+		AssertKeysUpDuration(state, new DateTime(200), new Dictionary<Keys, long> { { Keys.B, 80 }, { Keys.A, 70 } });
 		Assert.Equal(KeyModifierFlags.None, state.GetKeyModifiersDown());
 	}
 
@@ -70,11 +92,13 @@ public class KeysStateTest
 
 		AssertKeyDown(state, Keys.A, new DateTime(30), 20);
 		AssertKeysUp(state, excludedKeys: new HashSet<Keys> { Keys.A });
+		AssertKeysUpDuration(state, new DateTime(0));
 		Assert.Equal(KeyModifierFlags.None, state.GetKeyModifiersDown());
 
 		state.Record(new(Keys.A, KeyPressedState.Up), new DateTime(100));
 
 		AssertKeysUp(state, excludedKeys: new HashSet<Keys>());
+		AssertKeysUpDuration(state, new DateTime(180), new Dictionary<Keys, long> { { Keys.A, 80 } });
 		Assert.Equal(KeyModifierFlags.None, state.GetKeyModifiersDown());
 
 		state.Record(new(Keys.A, KeyPressedState.Up), new DateTime(110));
@@ -82,6 +106,7 @@ public class KeysStateTest
 		state.Record(new(Keys.A, KeyPressedState.Up), new DateTime(130));
 
 		AssertKeysUp(state, excludedKeys: new HashSet<Keys>());
+		AssertKeysUpDuration(state, new DateTime(180), new Dictionary<Keys, long> { { Keys.A, 50 } });
 		Assert.Equal(KeyModifierFlags.None, state.GetKeyModifiersDown());
 	}
 
@@ -100,6 +125,7 @@ public class KeysStateTest
 		AssertKeyDown(state, Keys.ShiftKey, new DateTime(30), 20);
 		AssertKeyDown(state, Keys.Shift, new DateTime(30), 20);
 		AssertKeysUp(state, new HashSet<Keys> { Keys.LShiftKey, Keys.ShiftKey, Keys.Shift, Keys.Modifiers });
+		AssertKeysUpDuration(state, new DateTime(30));
 		Assert.Equal(KeyModifierFlags.Shift, state.GetKeyModifiersDown());
 
 		state.Record(new(Keys.LControlKey, KeyPressedState.Down), new DateTime(20));
@@ -109,6 +135,7 @@ public class KeysStateTest
 		AssertKeyDown(state, Keys.ControlKey, new DateTime(50), 30);
 		AssertKeyDown(state, Keys.Control, new DateTime(50), 30);
 		AssertKeysUp(state, new HashSet<Keys> { Keys.LShiftKey, Keys.ShiftKey, Keys.Shift, Keys.LControlKey, Keys.ControlKey, Keys.Control, Keys.Modifiers });
+		AssertKeysUpDuration(state, new DateTime(50));
 		Assert.Equal(KeyModifierFlags.Shift | KeyModifierFlags.Control, state.GetKeyModifiersDown());
 
 		state.Record(new(Keys.LMenu, KeyPressedState.Down), new DateTime(60));
@@ -118,6 +145,7 @@ public class KeysStateTest
 		AssertKeyDown(state, Keys.Menu, new DateTime(120), 60);
 		AssertKeyDown(state, Keys.Alt, new DateTime(120), 60);
 		AssertKeysUp(state, new HashSet<Keys> { Keys.LShiftKey, Keys.ShiftKey, Keys.Shift, Keys.LControlKey, Keys.ControlKey, Keys.Control, Keys.LMenu, Keys.Menu, Keys.Alt, Keys.Modifiers });
+		AssertKeysUpDuration(state, new DateTime(120));
 		Assert.Equal(KeyModifierFlags.Shift | KeyModifierFlags.Control | KeyModifierFlags.Alt, state.GetKeyModifiersDown());
 	}
 

--- a/Vimfinity.Tests/VimKeyInterceptorTests.cs
+++ b/Vimfinity.Tests/VimKeyInterceptorTests.cs
@@ -139,23 +139,55 @@ public class VimKeyInterceptorTests
 	}
 
 	[Fact]
-	public void QuickReleaseVimKeyAfterVimBinding_Test()
+	public void QuickReleaseVimKeyAfterVimBindingDown_Test()
 	{
 		VimKeyInterceptor interceptor = CreateInterceptor(out List<string> outputLog);
 		HookAction action;
 
-		action = interceptor.VimIntercept(new(interceptor.VimKey, KeyPressedState.Down), new DateTime(10));
+		// Releasing Vim-bound key
+		action = interceptor.VimIntercept(new(Keys.X, KeyPressedState.Up), new DateTime(10));
+		Assert.Equal(HookAction.ForwardKey, action);
+		Assert.Empty(outputLog);
+
+		action = interceptor.VimIntercept(new(interceptor.VimKey, KeyPressedState.Down), new DateTime(110));
 		Assert.Equal(HookAction.SwallowKey, action);
 		Assert.Empty(outputLog);
 
 		// Pressing Vim-bound key before vim key min hold duration.
-		action = interceptor.VimIntercept(new(Keys.X, KeyPressedState.Down), new DateTime(20));
+		action = interceptor.VimIntercept(new(Keys.X, KeyPressedState.Down), new DateTime(120));
 		Assert.Equal(HookAction.SwallowKey, action);
 		Assert.Equal(1, outputLog.Count);
 		Assert.Equal(interceptor.VimBindings[(KeyModifierFlags.None, Keys.X)], outputLog.Last());
 
-		// Releasing Vim-bound key before vim key min hold duration, but after a vim-bound key was pressed.
-		action = interceptor.VimIntercept(new(interceptor.VimKey, KeyPressedState.Up), new DateTime(60));
+		// Releasing Vim key before vim key min hold duration, but after a vim-bound key was pressed.
+		action = interceptor.VimIntercept(new(interceptor.VimKey, KeyPressedState.Up), new DateTime(160));
+		Assert.Equal(HookAction.SwallowKey, action);
+		Assert.Equal(1, outputLog.Count);
+	}
+
+	[Fact]
+	public void QuickReleaseVimKeyAfterVimBindingUp_Test()
+	{
+		VimKeyInterceptor interceptor = CreateInterceptor(out List<string> outputLog);
+		HookAction action;
+
+		action = interceptor.VimIntercept(new(interceptor.VimKey, KeyPressedState.Down), new DateTime(110));
+		Assert.Equal(HookAction.SwallowKey, action);
+		Assert.Empty(outputLog);
+
+		// Pressing Vim-bound key before vim key min hold duration.
+		action = interceptor.VimIntercept(new(Keys.X, KeyPressedState.Down), new DateTime(120));
+		Assert.Equal(HookAction.SwallowKey, action);
+		Assert.Equal(1, outputLog.Count);
+		Assert.Equal(interceptor.VimBindings[(KeyModifierFlags.None, Keys.X)], outputLog.Last());
+
+		// Releasing Vim-bound key
+		action = interceptor.VimIntercept(new(Keys.X, KeyPressedState.Up), new DateTime(130));
+		Assert.Equal(HookAction.ForwardKey, action);
+		Assert.Equal(1, outputLog.Count);
+
+		// Releasing Vim key before vim key min hold duration, but after a vim-bound key was pressed.
+		action = interceptor.VimIntercept(new(interceptor.VimKey, KeyPressedState.Up), new DateTime(160));
 		Assert.Equal(HookAction.SwallowKey, action);
 		Assert.Equal(1, outputLog.Count);
 	}

--- a/Vimfinity.Tests/VimKeyInterceptorTests.cs
+++ b/Vimfinity.Tests/VimKeyInterceptorTests.cs
@@ -30,6 +30,7 @@ public class VimKeyInterceptorTests
 			{ (KeyModifierFlags.Shift, Keys.X), "{Backspace}" },
 			{ (KeyModifierFlags.None, Keys.X), "{Delete}" },
 		};
+		interceptor.VimKey = Keys.OemSemicolon;
 
 		outputLog = log;
 		return interceptor;

--- a/Vimfinity/KeysRecord.cs
+++ b/Vimfinity/KeysRecord.cs
@@ -1,0 +1,91 @@
+﻿namespace Vimfinity;
+
+internal class KeysRecord
+{
+	private Dictionary<Keys, DateTime> _downStartTimesUtc = new();
+	private Dictionary<Keys, DateTime> _upTimesUtc = new();
+
+	public void Record(KeysArgs args, DateTime nowUtc)
+	{
+		if (args.PressedState == KeyPressedState.Up)
+		{
+			_upTimesUtc[args.Key] = nowUtc;
+
+			if (_downStartTimesUtc.ContainsKey(args.Key))
+			{
+				_downStartTimesUtc.Remove(args.Key);
+			}
+		}
+		else if (args.PressedState == KeyPressedState.Down && !_downStartTimesUtc.ContainsKey(args.Key))
+		{
+			_downStartTimesUtc[args.Key] = nowUtc;
+		}
+	}
+
+	public void Record(KeysArgs args)
+	{
+		Record(args, DateTime.UtcNow);
+	}
+
+	public TimeSpan? GetKeyDownDuration(Keys key, DateTime nowUtc)
+	{
+		if (GetKeyRecord(_downStartTimesUtc, key, true) is not DateTime downStartUtc)
+		{
+			return null;
+		}
+
+		return nowUtc - downStartUtc;
+	}
+
+	public TimeSpan? GetKeyDownDuration(Keys key)
+	{
+		return GetKeyDownDuration(key, DateTime.UtcNow);
+	}
+
+	public TimeSpan? GetKeyUpDuration(Keys key, DateTime nowUtc)
+	{
+		if (GetKeyRecord(_upTimesUtc, key, false) is not DateTime upTimeUtc)
+		{
+			return null;
+		}
+
+		return nowUtc - upTimeUtc;
+	}
+
+	public bool IsKeyDown(Keys key) => GetKeyRecord(_downStartTimesUtc, key, true) != null;
+
+	public KeyModifierFlags GetKeyModifiersDown()
+	{
+		KeyModifierFlags modifiers = KeyModifierFlags.None;
+		modifiers |= IsKeyDown(Keys.Control) ? KeyModifierFlags.Control : KeyModifierFlags.None;
+		modifiers |= IsKeyDown(Keys.Shift) ? KeyModifierFlags.Shift : KeyModifierFlags.None;
+		modifiers |= IsKeyDown(Keys.Alt) ? KeyModifierFlags.Alt : KeyModifierFlags.None;
+		return modifiers;
+	}
+
+	private DateTime? GetKeyRecord(Dictionary<Keys, DateTime> events, Keys key, bool useOldest)
+	{
+		DateTime? getRecord(IEnumerable<Keys> keys)
+		{
+			var selectedEvents = keys
+				.Select(k => events.TryGetValue(k, out DateTime eventTime) ? eventTime : (DateTime?)null)
+				.OfType<DateTime>()
+				.ToList();
+
+			if (selectedEvents.Any())
+			{
+				return useOldest ? selectedEvents.Min() : selectedEvents.Max();
+			}
+			return null;
+		}
+
+		return key switch
+		{
+			Keys.Modifiers => getRecord([Keys.LMenu, Keys.RMenu, Keys.LShiftKey, Keys.RShiftKey, Keys.LControlKey, Keys.RControlKey]),
+			Keys.Menu or Keys.Alt => getRecord([Keys.LMenu, Keys.RMenu]),
+			Keys.ShiftKey or Keys.Shift => getRecord([Keys.LShiftKey, Keys.RShiftKey]),
+			Keys.ControlKey or Keys.Control => getRecord([Keys.LControlKey, Keys.RControlKey]),
+			_ => getRecord([key]),
+		};
+	}
+}

--- a/Vimfinity/KeysRecord.cs
+++ b/Vimfinity/KeysRecord.cs
@@ -22,11 +22,6 @@ internal class KeysRecord
 		}
 	}
 
-	public void Record(KeysArgs args)
-	{
-		Record(args, DateTime.UtcNow);
-	}
-
 	public TimeSpan? GetKeyDownDuration(Keys key, DateTime nowUtc)
 	{
 		if (GetKeyRecord(_downStartTimesUtc, key, true) is not DateTime downStartUtc)
@@ -35,11 +30,6 @@ internal class KeysRecord
 		}
 
 		return nowUtc - downStartUtc;
-	}
-
-	public TimeSpan? GetKeyDownDuration(Keys key)
-	{
-		return GetKeyDownDuration(key, DateTime.UtcNow);
 	}
 
 	public TimeSpan? GetKeyUpDuration(Keys key, DateTime nowUtc)


### PR DESCRIPTION
Instead of using a special variable to determine if a binding was pressed while the vim key was down, I added a record of when keys were raised. Allowing for a uniform experience.