### PR TITLE
Continue holding recent modifiers on vim key release

### DIFF
--- a/Vimfinity.Tests/KeysRecordTest.cs
+++ b/Vimfinity.Tests/KeysRecordTest.cs
@@ -178,6 +178,31 @@ public class KeysRecordTest
 	}
 
 	[Fact]
+	public void RecordModifiersDownUp_Test()
+	{
+		KeysRecord state = new();
+
+		AssertKeysUp(state, excludedKeys: new HashSet<Keys>());
+		Assert.Equal(KeyModifierFlags.None, state.GetKeyModifiersDown());
+
+		state.Record(new(Keys.LShiftKey, KeyPressedState.Down), new DateTime(10));
+
+		AssertKeyDown(state, Keys.Modifiers, new DateTime(30), 20);
+		AssertKeyDown(state, Keys.LShiftKey, new DateTime(30), 20);
+		AssertKeyDown(state, Keys.ShiftKey, new DateTime(30), 20);
+		AssertKeyDown(state, Keys.Shift, new DateTime(30), 20);
+		AssertKeysUp(state, new HashSet<Keys> { Keys.LShiftKey, Keys.ShiftKey, Keys.Shift, Keys.Modifiers });
+		AssertKeysUpDuration(state, new DateTime(40));
+		Assert.Equal(KeyModifierFlags.Shift, state.GetKeyModifiersDown());
+
+		state.Record(new(Keys.LShiftKey, KeyPressedState.Up), new DateTime(20));
+
+		AssertKeysUp(state, excludedKeys: new HashSet<Keys>());
+		AssertKeysUpDuration(state, new DateTime(60), new Dictionary<Keys, long> { { Keys.LShiftKey, 40 }, { Keys.ShiftKey, 40 }, { Keys.Shift, 40 }, { Keys.Modifiers, 40 } });
+		Assert.Equal(KeyModifierFlags.None, state.GetKeyModifiersDown());
+	}
+
+	[Fact]
 	public void RecordUpWithoutDown_Test()
 	{
 		KeysRecord state = new();

--- a/Vimfinity/Keys.cs
+++ b/Vimfinity/Keys.cs
@@ -41,6 +41,8 @@ internal enum KeyModifierFlags
 
 internal static class KeysExtensions
 {
+	public static readonly IEnumerable<Keys> ModifierKeys = [Keys.ShiftKey, Keys.ControlKey, Keys.Menu];
+
 	private static readonly HashSet<Keys> _EscapedNameKeys = [
 		Keys.CapsLock,
 		Keys.Delete,
@@ -66,6 +68,7 @@ internal static class KeysExtensions
 			return $"{{{key.ToString().ToUpper()}}}";
 		}
 
+		// https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.sendkeys.send?view=windowsdesktop-8.0&redirectedfrom=MSDN#System_Windows_Forms_SendKeys_Send_System_String_
 		return key switch
 		{
 			Keys.PageDown => "{PGDN}",
@@ -80,6 +83,9 @@ internal static class KeysExtensions
 			Keys.OemBackslash => "\\",
 			Keys.OemQuestion => "/",
 			Keys.OemMinus => "-",
+			Keys.ShiftKey or Keys.Shift => "+",
+			Keys.ControlKey or Keys.Control => "^",
+			Keys.Menu or Keys.Alt => "%",
 			_ => key.ToString(),
 		};
 	}


### PR DESCRIPTION
Normally, a keypress is sent as soon as a key is pressed down. However, the modifier key was changed to only send the keypress once the key has been released. This causes issues when the user releases a modifier key before releasing the vim key, because then the normal key is signalled instead of the intended modified key.
The solution in this commit is to pretend any recently released modifier keys are still held down when the vim key is released.